### PR TITLE
feat: campaign story, photos, edit & privacy features

### DIFF
--- a/backend/models/campaign.py
+++ b/backend/models/campaign.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from pydantic import BaseModel, Field, validator
 
 
@@ -15,6 +15,9 @@ class Campaign(BaseModel):
     currency: str = Field(default="USD")
     creator_email: Optional[str] = None
     status: str = Field(default="active")
+    is_public: bool = Field(default=True)
+    story: Optional[str] = Field(None, max_length=10000)
+    photos: Optional[List[str]] = Field(default_factory=list)  # Base64 or URLs
     end_date: Optional[datetime] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None

--- a/backend/routes/campaigns.py
+++ b/backend/routes/campaigns.py
@@ -78,6 +78,9 @@ def get_campaigns():
 
         if creator_id:
             query = query.eq('creator_id', creator_id)
+        else:
+            # When no specific creator is requested, only show public campaigns
+            query = query.eq('is_public', True)
 
         response = query.order('created_at', desc=True).range(offset, offset + limit - 1).execute()
         campaigns = [Campaign.from_dict(c).dict() for c in response.data]
@@ -159,7 +162,8 @@ def update_campaign(campaign_id):
         
         # Update only allowed fields
         allowed_fields = [
-            'title', 'description', 'target_amount', 'status', 'end_date'
+            'title', 'description', 'target_amount', 'status', 'end_date',
+            'story', 'photos', 'is_public'
         ]
         
         update_data = {

--- a/backend/supabase_setup.sql
+++ b/backend/supabase_setup.sql
@@ -9,16 +9,24 @@ CREATE TABLE IF NOT EXISTS campaigns (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     title VARCHAR(200) NOT NULL,
     description TEXT NOT NULL,
+    story TEXT,                                   -- Long-form campaign story
+    photos JSONB DEFAULT '[]'::jsonb,             -- Array of image data URLs / public URLs
     target_amount DECIMAL(15, 2) NOT NULL CHECK (target_amount > 0),
     current_amount DECIMAL(15, 2) NOT NULL DEFAULT 0 CHECK (current_amount >= 0),
     currency VARCHAR(10) NOT NULL DEFAULT 'SATS',
     creator_id VARCHAR(255) NOT NULL,
     creator_email VARCHAR(255),
     status VARCHAR(20) NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed', 'cancelled', 'expired')),
+    is_public BOOLEAN NOT NULL DEFAULT TRUE,          -- If false, hidden from public Explore page
     end_date TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
+
+-- Run these on existing databases to add the new columns:
+-- ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS story TEXT;
+-- ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS photos JSONB DEFAULT '[]'::jsonb;
+-- ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT TRUE;
 
 -- Contributions Table
 -- Stores Lightning payment details from LNbits

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { CampaignsProvider } from "@/contexts/CampaignsContext";
 import Landing from "./pages/Landing";
 import Dashboard from "./pages/Dashboard";
 import CreateCampaign from "./pages/CreateCampaign";
+import EditCampaign from "./pages/EditCampaign";
 import Campaign from "./pages/Campaign";
 import ExploreCampaigns from "./pages/ExploreCampaigns";
 import SignIn from "./pages/SignIn";
@@ -36,23 +37,24 @@ const App = () => (
           <BrowserRouter>
             <MockAuthProvider>
               <CampaignsProvider>
-              <Routes>
-                <Route path="/" element={<Landing />} />
-                <Route path="/signin" element={<SignIn />} />
-                <Route path="/signup" element={<SignUp />} />
-                <Route path="/forgot-password" element={<ForgotPassword />} />
-                <Route path="/app" element={<AppLayout><Dashboard /></AppLayout>} />
-                <Route path="/explore" element={<ExploreCampaigns />} />
-                <Route path="/create" element={<AppLayout><CreateCampaign /></AppLayout>} />
-                <Route path="/my-links" element={<AppLayout><MyLinks /></AppLayout>} />
-                <Route path="/contributions" element={<AppLayout><Contributions /></AppLayout>} />
-                <Route path="/wallet" element={<AppLayout><Wallet /></AppLayout>} />
-                <Route path="/notifications" element={<AppLayout><Notifications /></AppLayout>} />
-                <Route path="/settings" element={<AppLayout><ProfileSettings /></AppLayout>} />
-                <Route path="/support" element={<AppLayout><Support /></AppLayout>} />
-                <Route path="/c/:id" element={<Campaign />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
+                <Routes>
+                  <Route path="/" element={<Landing />} />
+                  <Route path="/signin" element={<SignIn />} />
+                  <Route path="/signup" element={<SignUp />} />
+                  <Route path="/forgot-password" element={<ForgotPassword />} />
+                  <Route path="/app" element={<AppLayout><Dashboard /></AppLayout>} />
+                  <Route path="/explore" element={<ExploreCampaigns />} />
+                  <Route path="/create" element={<AppLayout><CreateCampaign /></AppLayout>} />
+                  <Route path="/my-links" element={<AppLayout><MyLinks /></AppLayout>} />
+                  <Route path="/contributions" element={<AppLayout><Contributions /></AppLayout>} />
+                  <Route path="/wallet" element={<AppLayout><Wallet /></AppLayout>} />
+                  <Route path="/notifications" element={<AppLayout><Notifications /></AppLayout>} />
+                  <Route path="/settings" element={<AppLayout><ProfileSettings /></AppLayout>} />
+                  <Route path="/support" element={<AppLayout><Support /></AppLayout>} />
+                  <Route path="/c/:id" element={<Campaign />} />
+                  <Route path="/edit/:id" element={<AppLayout><EditCampaign /></AppLayout>} />
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
               </CampaignsProvider>
             </MockAuthProvider>
           </BrowserRouter>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import Wallet from "./pages/Wallet";
 import Notifications from "./pages/Notifications";
 import Support from "./pages/Support";
 import NotFound from "./pages/NotFound";
+// import AuthCallback from "@/pages/AuthCallback";
 
 const queryClient = new QueryClient();
 
@@ -38,10 +39,16 @@ const App = () => (
             <MockAuthProvider>
               <CampaignsProvider>
                 <Routes>
+                  {/* Public routes */}
                   <Route path="/" element={<Landing />} />
                   <Route path="/signin" element={<SignIn />} />
                   <Route path="/signup" element={<SignUp />} />
                   <Route path="/forgot-password" element={<ForgotPassword />} />
+
+                  {/* Auth callback — uncomment when Google Auth is wired up */}
+                  {/* <Route path="/auth/callback" element={<AuthCallback />} /> */}
+
+                  {/* Protected routes */}
                   <Route path="/app" element={<AppLayout><Dashboard /></AppLayout>} />
                   <Route path="/explore" element={<ExploreCampaigns />} />
                   <Route path="/create" element={<AppLayout><CreateCampaign /></AppLayout>} />
@@ -51,8 +58,12 @@ const App = () => (
                   <Route path="/notifications" element={<AppLayout><Notifications /></AppLayout>} />
                   <Route path="/settings" element={<AppLayout><ProfileSettings /></AppLayout>} />
                   <Route path="/support" element={<AppLayout><Support /></AppLayout>} />
+
+                  {/* Campaign public & edit routes */}
                   <Route path="/c/:id" element={<Campaign />} />
                   <Route path="/edit/:id" element={<AppLayout><EditCampaign /></AppLayout>} />
+
+                  {/* 404 must be last */}
                   <Route path="*" element={<NotFound />} />
                 </Routes>
               </CampaignsProvider>

--- a/frontend/src/components/PaymentModal.tsx
+++ b/frontend/src/components/PaymentModal.tsx
@@ -8,7 +8,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Copy, Check, Loader2, Zap, ArrowLeftRight } from "lucide-react";
+import { Copy, Check, Loader2, Zap, ArrowLeftRight, Bitcoin } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import {
   Dialog,
@@ -23,7 +23,7 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { useBtcRate, kesToSats, satsToKes } from "@/hooks/useBtcRate";
 import mpesaLogo from "@/assets/mpesa-logo.png";
-import bitcoinLogo from "@/assets/bitcoin-logo.png";
+import crowdpayLogo from "@/assets/logo.png";
 
 // API configuration
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
@@ -251,8 +251,8 @@ export const PaymentModal = ({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Zap className="w-5 h-5 text-bitcoin" />
-            Choose Payment Method
+            <img src={crowdpayLogo} alt="CrowdPay" className="w-7 h-7 object-contain" />
+            <span>Contribute to <span className="text-bitcoin">{campaignTitle}</span></span>
           </DialogTitle>
         </DialogHeader>
 
@@ -269,14 +269,8 @@ export const PaymentModal = ({
               M-Pesa
             </TabsTrigger>
             <TabsTrigger value="bitcoin" className="gap-2 group">
-              <motion.img
-                src={bitcoinLogo}
-                alt="Bitcoin"
-                className="w-5 h-5"
-                whileHover={{ scale: 1.2, rotate: -5 }}
-                transition={{ type: "spring", stiffness: 300 }}
-              />
-              Bitcoin
+              <Bitcoin className="w-4 h-4 text-bitcoin" />
+              Bitcoin ⚡
             </TabsTrigger>
           </TabsList>
 
@@ -441,13 +435,7 @@ export const PaymentModal = ({
                       </>
                     ) : (
                       <>
-                        <motion.img
-                          src={bitcoinLogo}
-                          alt="Bitcoin"
-                          className="w-5 h-5"
-                          whileHover={{ scale: 1.15, rotate: 360 }}
-                          transition={{ type: "spring", stiffness: 300 }}
-                        />
+                        <Zap className="w-5 h-5" />
                         Pay {satAmount.toLocaleString()} sats with Lightning
                       </>
                     )}

--- a/frontend/src/pages/Campaign.tsx
+++ b/frontend/src/pages/Campaign.tsx
@@ -1,25 +1,344 @@
 /**
- * Campaign Page - Public view of a single campaign
+ * Campaign Page – Geyser Fund-inspired layout
  *
- * Features:
- * - Campaign details display (fetched from backend)
- * - Progress tracking with real data
- * - Lightning payment integration via LNbits
- * - Social sharing
+ * Layout (desktop):
+ *   ┌─ LEFT (60%) ──────────────────┐  ┌─ RIGHT (40%) ──────────────┐
+ *   │  Photo carousel               │  │  Static contribute widget   │
+ *   │  Campaign title / creator     │  │  (always visible)           │
+ *   │  Story                        │  │  Contributions feed         │
+ *   │  Contributions feed (mobile)  │  └────────────────────────────┘
+ *   └───────────────────────────────┘
+ *
+ * Mobile: contribute widget renders FIRST (order-first class),
+ *         then photo, then story.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
-import { campaignApi } from "@/services/api";
+import { campaignApi, ContributionItem } from "@/services/api";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { useToast } from "@/hooks/use-toast";
-import { Bitcoin, Share2, Sun, Moon, Zap, Loader2, AlertCircle } from "lucide-react";
+import {
+  Bitcoin,
+  Share2,
+  Sun,
+  Moon,
+  Zap,
+  Loader2,
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  ShieldCheck,
+  Clock,
+  Heart,
+  Smartphone,
+  DollarSign,
+  Pencil,
+} from "lucide-react";
 import { PaymentModal } from "@/components/PaymentModal";
+import crowdpayLogo from "@/assets/logo.png";
+import { useAuth } from "@/contexts/MockAuthContext";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diff = Math.floor((now - then) / 1000);
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 2592000) return `${Math.floor(diff / 86400)} days ago`;
+  if (diff < 31536000) return `${Math.floor(diff / 2592000)} months ago`;
+  return `${Math.floor(diff / 31536000)} years ago`;
+}
+
+// ─── Photo Carousel ──────────────────────────────────────────────────────────
+// Matches Geyser Fund: contained box, not full-width, with arrow buttons on sides
+
+function PhotoCarousel({ photos }: { photos: string[] }) {
+  const [current, setCurrent] = useState(0);
+
+  const prev = useCallback(
+    () => setCurrent(c => (c - 1 + photos.length) % photos.length),
+    [photos.length]
+  );
+  const next = useCallback(
+    () => setCurrent(c => (c + 1) % photos.length),
+    [photos.length]
+  );
+
+  if (photos.length === 0) return null;
+
+  return (
+    <div className="relative w-full rounded-xl overflow-hidden bg-black" style={{ aspectRatio: "4/3", maxHeight: "400px" }}>
+      {/* Blurred backdrop for portrait images */}
+      <div
+        className="absolute inset-0"
+        style={{
+          backgroundImage: `url(${photos[current]})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          filter: "blur(18px) brightness(0.35)",
+          transform: "scale(1.1)",
+        }}
+      />
+
+      {/* Main image — always fully visible */}
+      <img
+        src={photos[current]}
+        alt={`Photo ${current + 1}`}
+        className="relative w-full h-full object-contain transition-opacity duration-300"
+        draggable={false}
+      />
+
+      {photos.length > 1 && (
+        <>
+          <button
+            onClick={prev}
+            className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/60 hover:bg-black/80 text-white rounded-full p-1.5 transition-colors z-10"
+            aria-label="Previous photo"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+          <button
+            onClick={next}
+            className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/60 hover:bg-black/80 text-white rounded-full p-1.5 transition-colors z-10"
+            aria-label="Next photo"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+
+          {/* Dot navigation */}
+          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1.5 z-10">
+            {photos.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setCurrent(i)}
+                className={`rounded-full transition-all ${i === current
+                  ? "bg-white w-4 h-2"
+                  : "bg-white/50 w-2 h-2"
+                  }`}
+                aria-label={`Go to photo ${i + 1}`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Contribution Feed Item ──────────────────────────────────────────────────
+
+function ContributionFeedItem({ contrib }: { contrib: ContributionItem }) {
+  const name =
+    contrib.is_anonymous || !contrib.contributor_name
+      ? "Anonymous"
+      : contrib.contributor_name;
+
+  const colors = [
+    "bg-orange-500", "bg-green-600", "bg-blue-500",
+    "bg-purple-600", "bg-pink-500", "bg-teal-500",
+  ];
+  const avatarColor = colors[name.charCodeAt(0) % colors.length];
+
+  return (
+    <div className="flex items-start gap-3 py-3 border-b last:border-b-0">
+      <div
+        className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-white text-xs font-bold ${avatarColor}`}
+      >
+        {name[0].toUpperCase()}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline justify-between gap-2 flex-wrap">
+          <p className="text-sm">
+            <span className="font-semibold">{name}</span>
+            <span className="text-muted-foreground"> contributed </span>
+            <span className="font-bold" style={{ color: "#F7931A" }}>
+              {contrib.amount.toLocaleString()} SATS
+            </span>
+          </p>
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {timeAgo(contrib.created_at)}
+          </span>
+        </div>
+        {contrib.message && (
+          <p className="text-xs text-muted-foreground mt-0.5 italic">
+            "{contrib.message}"
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Static Contribute Widget ────────────────────────────────────────────────
+
+interface ContributeWidgetProps {
+  campaign: {
+    id: string;
+    title: string;
+    current_amount: number;
+    target_amount: number;
+    currency: string;
+    status: string;
+    end_date?: string;
+  };
+  statistics?: {
+    progress_percentage: number;
+    paid_contributions: number;
+    is_goal_reached: boolean;
+  };
+  contributions: ContributionItem[];
+  onContribute: () => void;
+  onShare: () => void;
+}
+
+function ContributeWidget({
+  campaign,
+  statistics,
+  contributions,
+  onContribute,
+  onShare,
+}: ContributeWidgetProps) {
+  const [showAll, setShowAll] = useState(false);
+  const progress = statistics?.progress_percentage || 0;
+  const themeColor = "#F7931A";
+
+  const displayed = showAll ? contributions : contributions.slice(0, 5);
+
+  return (
+    <div className="space-y-4">
+      {/* ── Raised amount + progress ── */}
+      <Card className="p-5 space-y-5">
+        <div className="space-y-3">
+          <div>
+            <p className="text-3xl font-bold" style={{ color: themeColor }}>
+              {campaign.current_amount.toLocaleString()}
+              <span className="text-base font-normal ml-1">{campaign.currency}</span>
+            </p>
+            <p className="text-sm text-muted-foreground">
+              raised of {campaign.target_amount.toLocaleString()} {campaign.currency} goal
+            </p>
+          </div>
+
+          {/* Circular-style progress */}
+          <Progress value={progress} className="h-2" />
+
+          <div className="flex items-center gap-3 text-sm text-muted-foreground">
+            <span>
+              <strong className="text-foreground">
+                {statistics?.paid_contributions ?? 0}
+              </strong>{" "}
+              contributions
+            </span>
+            {statistics?.is_goal_reached && (
+              <Badge variant="default" className="bg-green-500">
+                Goal Reached! 🎉
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        {/* ── CTA ── */}
+        <Button
+          size="lg"
+          className="w-full text-white font-bold py-6 text-base gap-2"
+          style={{ backgroundColor: themeColor }}
+          onClick={onContribute}
+          disabled={campaign.status !== "active"}
+        >
+          <Zap className="w-5 h-5" />
+          {campaign.status === "active"
+            ? "Contribute"
+            : `Campaign ${campaign.status}`}
+        </Button>
+
+        {/* Payment methods */}
+        <div className="flex items-center justify-center gap-2 flex-wrap text-xs text-muted-foreground">
+          <Bitcoin className="w-3.5 h-3.5 text-[#F7931A]" />
+          <span>Bitcoin Lightning</span>
+          <span>·</span>
+          <Smartphone className="w-3.5 h-3.5 text-green-600" />
+          <span className="opacity-60">M-Pesa (soon)</span>
+          <span>·</span>
+          <DollarSign className="w-3.5 h-3.5 text-blue-500" />
+          <span className="opacity-60">USDT (soon)</span>
+        </div>
+
+        {/* Share */}
+        <Button variant="outline" className="w-full" size="sm" onClick={onShare}>
+          <Share2 className="w-4 h-4 mr-2" />
+          Share this campaign
+        </Button>
+
+        {campaign.end_date && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground pt-1">
+            <Clock className="w-3.5 h-3.5" />
+            <span>
+              Ends{" "}
+              {new Date(campaign.end_date).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </span>
+          </div>
+        )}
+      </Card>
+
+      {/* ── Contributions feed ── */}
+      <Card className="p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="font-semibold text-sm">Contributions</h3>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <ShieldCheck className="w-3.5 h-3.5 text-green-500" />
+            <span>Verified</span>
+          </div>
+        </div>
+
+        {/* Transparency note */}
+        <div className="flex items-start gap-2 p-2 bg-green-50 dark:bg-green-950/30 rounded-lg border border-green-100 dark:border-green-900">
+          <Heart className="w-3 h-3 text-green-600 mt-0.5 shrink-0" />
+          <p className="text-xs text-green-700 dark:text-green-400 leading-snug">
+            All contributions are transparently recorded. Contributors may remain anonymous.
+          </p>
+        </div>
+
+        {contributions.length === 0 ? (
+          <div className="text-center py-6 text-muted-foreground">
+            <Zap className="w-6 h-6 mx-auto mb-1 opacity-40" />
+            <p className="text-sm">Be the first to contribute!</p>
+          </div>
+        ) : (
+          <>
+            {displayed.map(c => (
+              <ContributionFeedItem key={c.id} contrib={c} />
+            ))}
+            {contributions.length > 5 && (
+              <button
+                onClick={() => setShowAll(s => !s)}
+                className="text-xs text-muted-foreground hover:text-foreground w-full text-center pt-1 pb-0.5 transition-colors"
+              >
+                {showAll
+                  ? "Show less"
+                  : `See all ${contributions.length} contributions`}
+              </button>
+            )}
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
 
 const Campaign = () => {
   const { id } = useParams<{ id: string }>();
@@ -27,69 +346,7 @@ const Campaign = () => {
   const { toast } = useToast();
   const [paymentModalOpen, setPaymentModalOpen] = useState(false);
 
-  // Fetch campaign data from backend
-  const {
-    data,
-    isLoading,
-    error,
-    refetch,
-  } = useQuery({
-    queryKey: ["campaign", id],
-    queryFn: async () => {
-      if (!id) throw new Error("Campaign ID is required");
-      return campaignApi.get(id);
-    },
-    enabled: !!id,
-    staleTime: 10000, // 10 seconds
-    refetchOnWindowFocus: true,
-  });
-
-  const campaign = data?.campaign;
-  const statistics = data?.statistics;
-
-  // Handle missing campaign
-  useEffect(() => {
-    if (error) {
-      toast({
-        title: "Campaign not found",
-        description: "This campaign doesn't exist or has been removed",
-        variant: "destructive",
-      });
-    }
-  }, [error, toast]);
-
-  const handlePayment = () => {
-    setPaymentModalOpen(true);
-  };
-
-  const handlePaymentSuccess = () => {
-    toast({
-      title: "Thank you!",
-      description: "Your contribution has been received.",
-    });
-    // Refetch campaign data to update progress
-    refetch();
-  };
-
-  const campaignUrl = `${window.location.origin}/c/${id}`;
-
-  const shareLink = () => {
-    if (navigator.share) {
-      navigator.share({
-        title: campaign?.title,
-        text: campaign?.description || "Support this campaign",
-        url: campaignUrl,
-      });
-    } else {
-      navigator.clipboard.writeText(campaignUrl);
-      toast({
-        title: "Link copied!",
-        description: "Share it with your friends",
-      });
-    }
-  };
-
-  // Dark and light mode toggle
+  // Theme
   const [isDark, setIsDark] = useState(() => {
     if (typeof window !== "undefined") {
       const saved = localStorage.getItem("theme");
@@ -99,7 +356,6 @@ const Campaign = () => {
     return false;
   });
 
-  // Theme toggle logic
   useEffect(() => {
     const root = document.documentElement;
     if (isDark) {
@@ -111,9 +367,69 @@ const Campaign = () => {
     }
   }, [isDark]);
 
-  const toggleTheme = () => setIsDark(!isDark);
+  // ── Fetch campaign ──
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["campaign", id],
+    queryFn: async () => {
+      if (!id) throw new Error("Campaign ID is required");
+      return campaignApi.get(id);
+    },
+    enabled: !!id,
+    staleTime: 10000,
+    refetchOnWindowFocus: true,
+  });
 
-  // Loading state
+  // ── Fetch contributions ──
+  const { data: contribData, refetch: refetchContribs } = useQuery({
+    queryKey: ["campaign-contributions", id],
+    queryFn: async () => {
+      if (!id) return { contributions: [], count: 0 };
+      return campaignApi.getContributions(id);
+    },
+    enabled: !!id,
+    staleTime: 15000,
+    refetchOnWindowFocus: true,
+  });
+
+  const campaign = data?.campaign;
+  const statistics = data?.statistics;
+  const paidContributions: ContributionItem[] = (
+    contribData?.contributions || []
+  ).filter((c: ContributionItem) => c.payment_status === "paid");
+
+  useEffect(() => {
+    if (error) {
+      toast({
+        title: "Campaign not found",
+        description: "This campaign doesn't exist or has been removed",
+        variant: "destructive",
+      });
+    }
+  }, [error, toast]);
+
+  const handlePaymentSuccess = () => {
+    toast({ title: "Thank you! 🎉", description: "Your contribution has been received." });
+    refetch();
+    refetchContribs();
+  };
+
+  const { user } = useAuth();
+  const isOwner = !!(user && campaign && campaign.creator_id === user.id);
+  const campaignUrl = `${window.location.origin}/c/${id}`;
+  const shareLink = () => {
+    if (navigator.share) {
+      navigator.share({
+        title: campaign?.title,
+        text: campaign?.description || "Support this campaign",
+        url: campaignUrl,
+      });
+    } else {
+      navigator.clipboard.writeText(campaignUrl);
+      toast({ title: "Link copied!", description: "Share it with your friends" });
+    }
+  };
+
+  // ── Loading ──
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
@@ -125,7 +441,7 @@ const Campaign = () => {
     );
   }
 
-  // Error state
+  // ── Error ──
   if (error || !campaign) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
@@ -135,16 +451,13 @@ const Campaign = () => {
           <p className="text-muted-foreground">
             This campaign doesn't exist or has been removed.
           </p>
-          <Button onClick={() => navigate("/explore")}>
-            Browse Campaigns
-          </Button>
+          <Button onClick={() => navigate("/explore")}>Browse Campaigns</Button>
         </Card>
       </div>
     );
   }
 
-  const progress = statistics?.progress_percentage || 0;
-  const themeColor = "#F7931A"; // Bitcoin orange
+  const photos: string[] = Array.isArray(campaign.photos) ? campaign.photos : [];
 
   return (
     <>
@@ -154,8 +467,6 @@ const Campaign = () => {
           name="description"
           content={campaign.description || `Support ${campaign.title}`}
         />
-
-        {/* Open Graph / Facebook */}
         <meta property="og:type" content="website" />
         <meta property="og:url" content={window.location.href} />
         <meta property="og:title" content={`${campaign.title} - CrowdPay`} />
@@ -163,137 +474,122 @@ const Campaign = () => {
           property="og:description"
           content={campaign.description || `Support ${campaign.title}`}
         />
-
-        {/* Twitter */}
+        {photos[0] && <meta property="og:image" content={photos[0]} />}
         <meta property="twitter:card" content="summary_large_image" />
-        <meta property="twitter:url" content={window.location.href} />
-        <meta property="twitter:title" content={`${campaign.title} - CrowdPay`} />
-        <meta
-          property="twitter:description"
-          content={campaign.description || `Support ${campaign.title}`}
-        />
       </Helmet>
 
       <div className="min-h-screen bg-background">
-        {/* Navigation */}
-        <nav className="border-b bg-background">
-          <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+        {/* ── Nav ── */}
+        <nav className="border-b bg-background sticky top-0 z-40">
+          <div className="container mx-auto px-4 py-3 flex items-center justify-between max-w-5xl">
             <div
               className="flex items-center gap-2 cursor-pointer"
               onClick={() => navigate("/")}
             >
-              <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center">
-                <Bitcoin className="w-5 h-5 text-primary-foreground" />
-              </div>
+              <img src={crowdpayLogo} alt="CrowdPay" className="w-8 h-8 object-contain" />
               <span className="font-bold text-xl">CrowdPay</span>
             </div>
             <div className="flex items-center gap-2">
+              {isOwner && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => navigate(`/edit/${id}`)}
+                >
+                  <Pencil className="w-4 h-4 mr-2" />
+                  Edit
+                </Button>
+              )}
               <Button variant="ghost" size="sm" onClick={shareLink}>
                 <Share2 className="w-4 h-4 mr-2" />
                 Share
               </Button>
               <Button
-                onClick={toggleTheme}
+                onClick={() => setIsDark(!isDark)}
                 variant="secondary"
                 size="icon"
-                className="backdrop-blur-sm dark:text-white light: hover:bg-white/20"
                 aria-label="Toggle theme"
               >
-                {isDark ? (
-                  <Sun className="h-4 w-4" />
-                ) : (
-                  <Moon className="h-4 w-4" />
-                )}
+                {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
               </Button>
             </div>
           </div>
         </nav>
 
-        <div className="container mx-auto px-4 py-8 max-w-2xl">
-          <Card className="overflow-hidden">
-            <div className="p-6 space-y-6">
-              {/* Title & Description */}
+        <div className="container mx-auto px-4 py-6 max-w-5xl">
+          {/*
+           * Geyser-style 2-column grid:
+           *   desktop: [story col] [sidebar]
+           *   mobile:  sidebar first (order-first), then story (order-last)
+           */}
+          <div className="grid lg:grid-cols-[1fr_380px] gap-8 items-start">
+
+            {/* ── RIGHT COLUMN (sidebar) — appears first on mobile ── */}
+            <div className="order-first lg:order-last lg:sticky lg:top-20">
+              <ContributeWidget
+                campaign={campaign}
+                statistics={statistics}
+                contributions={paidContributions}
+                onContribute={() => setPaymentModalOpen(true)}
+                onShare={shareLink}
+              />
+            </div>
+
+            {/* ── LEFT COLUMN (story) ── */}
+            <div className="order-last lg:order-first space-y-6">
+
+              {/* Photo carousel — contained, Geyser-style */}
+              {photos.length > 0 && (
+                <PhotoCarousel photos={photos} />
+              )}
+
+              {/* Campaign title + status */}
               <div>
-                <div className="flex items-start justify-between gap-3 mb-3">
-                  <h1 className="text-3xl font-bold flex-1">{campaign.title}</h1>
-                  <Badge variant="secondary" className="shrink-0">
+                <div className="flex items-start gap-3 flex-wrap">
+                  <h1 className="text-2xl font-bold flex-1">{campaign.title}</h1>
+                  <Badge variant="secondary" className="shrink-0 mt-1">
                     {campaign.status === "active" ? "Active" : campaign.status}
                   </Badge>
                 </div>
                 {campaign.description && (
-                  <p className="text-muted-foreground whitespace-pre-wrap">
+                  <p className="text-muted-foreground mt-1 text-base">
                     {campaign.description}
                   </p>
                 )}
               </div>
 
-              {/* Progress */}
-              <div className="space-y-3">
-                <div className="flex justify-between items-baseline">
-                  <div>
-                    <p
-                      className="text-3xl font-bold"
-                      style={{ color: themeColor }}
-                    >
-                      {campaign.current_amount.toLocaleString()} {campaign.currency}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      raised of {campaign.target_amount.toLocaleString()} {campaign.currency} goal
-                    </p>
-                  </div>
-                  <p className="text-2xl font-semibold text-muted-foreground">
-                    {Math.round(progress)}%
-                  </p>
-                </div>
-                <Progress value={progress} className="h-3" />
-
-                {/* Statistics */}
-                {statistics && (
-                  <div className="flex gap-4 text-sm text-muted-foreground">
-                    <span>{statistics.paid_contributions} contributions</span>
-                    {statistics.is_goal_reached && (
-                      <Badge variant="default" className="bg-green-500">
-                        Goal Reached!
-                      </Badge>
+              {/* Story */}
+              {campaign.story && (
+                <div className="space-y-3">
+                  <h2 className="text-xl font-bold border-b pb-2">Story</h2>
+                  <div className="space-y-4">
+                    {campaign.story.split("\n").map((para, i) =>
+                      para.trim() ? (
+                        <p key={i} className="text-base leading-relaxed text-foreground">
+                          {para}
+                        </p>
+                      ) : (
+                        <div key={i} className="h-2" />
+                      )
                     )}
                   </div>
-                )}
-              </div>
-
-              {/* Lightning Payment Info */}
-              <div className="bg-muted rounded-lg p-4">
-                <div className="flex items-center gap-2 mb-2">
-                  <Zap className="w-5 h-5 text-bitcoin" />
-                  <span className="font-medium">Lightning Payments Only</span>
                 </div>
-                <p className="text-sm text-muted-foreground">
-                  This campaign accepts Bitcoin via the Lightning Network for
-                  instant, low-fee payments. Use any Lightning-compatible wallet
-                  to contribute.
-                </p>
-              </div>
+              )}
 
-              {/* Payment Button */}
-              <div className="pt-4">
-                <Button
-                  size="lg"
-                  className="w-full bg-bitcoin hover:bg-bitcoin/90 text-white gap-2"
-                  onClick={handlePayment}
-                  disabled={campaign.status !== "active"}
-                >
-                  <Zap className="w-5 h-5" />
-                  {campaign.status === "active"
-                    ? "Contribute with Lightning"
-                    : `Campaign ${campaign.status}`}
-                </Button>
-              </div>
+              {/* No photo placeholder */}
+              {photos.length === 0 && (
+                <div className="w-full h-48 rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center border border-dashed">
+                  <p className="text-muted-foreground text-sm">No photos added</p>
+                </div>
+              )}
 
-              {/* Info Text */}
-              <p className="text-xs text-center text-muted-foreground pt-4">
-                Powered by CrowdPay • Lightning Network fundraising via LNbits
+              {/* Powered by footer */}
+              <p className="text-xs text-center text-muted-foreground pt-4 pb-8">
+                Powered by CrowdPay · Bitcoin Lightning Network
               </p>
             </div>
-          </Card>
+
+          </div>
         </div>
       </div>
 

--- a/frontend/src/pages/CreateCampaign.tsx
+++ b/frontend/src/pages/CreateCampaign.tsx
@@ -7,12 +7,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { Store, Calendar, Shield, Loader2, Image as ImageIcon, Copy, Bitcoin, Smartphone, QrCode, MapPin, Clock, Users } from "lucide-react";
+import { Store, Calendar, Shield, Loader2, Image as ImageIcon, Copy, Bitcoin, Smartphone, QrCode, MapPin, Clock, Users, X, Plus } from "lucide-react";
 import { Helmet } from "react-helmet-async";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
@@ -40,6 +40,8 @@ const categoryLabels: Record<string, { label: string; emoji: string }> = {
   other: { label: "Other", emoji: "📦" },
 };
 
+const MAX_PHOTOS = 5;
+
 const CreateCampaign = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -47,11 +49,13 @@ const CreateCampaign = () => {
   const { createCampaign, refetchCampaigns } = useCampaigns();
   const { kesToSats: kesToSatsRate } = useBtcRate();
   const [loading, setLoading] = useState(false);
-  const [coverImagePreview, setCoverImagePreview] = useState<string>("");
+  const [photos, setPhotos] = useState<string[]>([]);
+  const [storyCharCount, setStoryCharCount] = useState(0);
 
   const [formData, setFormData] = useState({
     title: "",
     description: "",
+    story: "",
     goal_amount: "",
     mode: "merchant" as "merchant" | "event" | "activism",
     category: "other",
@@ -74,23 +78,37 @@ const CreateCampaign = () => {
     }
   }, [formData.title, formData.slug]);
 
-  const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      if (file.size > 5 * 1024 * 1024) {
-        toast({
-          title: "File too large",
-          description: "Please select an image under 5MB",
-          variant: "destructive",
-        });
-        return;
-      }
+  const handlePhotosSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (!files.length) return;
+
+    const remaining = MAX_PHOTOS - photos.length;
+    if (remaining <= 0) {
+      toast({ title: "Max photos reached", description: `You can upload up to ${MAX_PHOTOS} photos`, variant: "destructive" });
+      return;
+    }
+
+    const toProcess = files.slice(0, remaining);
+    const oversized = toProcess.filter(f => f.size > 5 * 1024 * 1024);
+    if (oversized.length > 0) {
+      toast({ title: "File too large", description: "Each photo must be under 5MB", variant: "destructive" });
+      return;
+    }
+
+    toProcess.forEach(file => {
       const reader = new FileReader();
       reader.onloadend = () => {
-        setCoverImagePreview(reader.result as string);
+        setPhotos(prev => [...prev, reader.result as string]);
       };
       reader.readAsDataURL(file);
-    }
+    });
+
+    // Reset the input so the same file can be re-selected
+    e.target.value = "";
+  };
+
+  const removePhoto = (index: number) => {
+    setPhotos(prev => prev.filter((_, i) => i !== index));
   };
 
   const handleFormSubmit = (e: React.FormEvent) => {
@@ -114,29 +132,24 @@ const CreateCampaign = () => {
     setLoading(true);
 
     try {
-      // Convert KES to satoshis for the target amount
       const targetInSats = formData.goal_amount
         ? kesToSats(parseFloat(formData.goal_amount), kesToSatsRate)
-        : 1000; // Default minimum if not specified
+        : 1000;
 
-      // Create campaign via backend API
       const newCampaign = await createCampaign({
         title: formData.title,
         description: formData.description || "No description provided.",
+        story: formData.story || undefined,
+        photos: photos.length > 0 ? photos : undefined,
+        is_public: formData.is_public,
         target_amount: targetInSats,
         currency: "SATS",
         end_date: formData.end_date || undefined,
       });
 
-      // Refetch campaigns to update the list
       refetchCampaigns();
 
-      toast({
-        title: "Campaign created!",
-        description: "Your campaign is now live.",
-      });
-
-      // Navigate to the new campaign page
+      toast({ title: "Campaign created!", description: "Your campaign is now live." });
       navigate(`/c/${newCampaign.id}`);
     } catch (error) {
       console.error("Error creating campaign:", error);
@@ -150,27 +163,20 @@ const CreateCampaign = () => {
     }
   };
 
-  const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+  const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
   const campaignUrl = `${baseUrl}/c/${formData.slug || "your-campaign"}`;
 
   const copyLink = () => {
     navigator.clipboard.writeText(campaignUrl);
-    toast({
-      title: "Link copied!",
-      description: "Share it with your supporters",
-    });
+    toast({ title: "Link copied!", description: "Share it with your supporters" });
   };
 
   const formatEndDate = (dateString: string) => {
     if (!dateString) return null;
     const date = new Date(dateString);
     return date.toLocaleDateString("en-US", {
-      weekday: "short",
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
+      weekday: "short", month: "short", day: "numeric", year: "numeric",
+      hour: "2-digit", minute: "2-digit",
     });
   };
 
@@ -188,53 +194,54 @@ const CreateCampaign = () => {
             <p className="text-muted-foreground">Set up your fundraising event with full customization</p>
           </div>
         </div>
+
         <div className="grid lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
-          {/* Form Section */}
+          {/* ── Form Section ── */}
           <Card>
             <CardContent>
               <form onSubmit={handleFormSubmit} className="space-y-6">
-                {/* Cover Image */}
+
+                {/* ── Photos Upload ── */}
                 <div className="space-y-2">
-                  <Label>Cover Image</Label>
-                  <div className="flex flex-col gap-4">
-                    {coverImagePreview ? (
-                      <div className="relative w-full h-48 rounded-lg overflow-hidden border">
-                        <img
-                          src={coverImagePreview}
-                          alt="Cover preview"
-                          className="w-full h-full object-cover"
-                        />
-                        <Button
+                  <Label>Photos <span className="text-muted-foreground text-xs">({photos.length}/{MAX_PHOTOS})</span></Label>
+                  <p className="text-xs text-muted-foreground">Upload up to {MAX_PHOTOS} photos to showcase your campaign. First photo is the cover.</p>
+
+                  {/* Photo grid */}
+                  <div className="grid grid-cols-5 gap-2">
+                    {photos.map((src, i) => (
+                      <div key={i} className="relative group w-full aspect-square rounded-lg overflow-hidden border bg-muted">
+                        <img src={src} alt={`Photo ${i + 1}`} className="w-full h-full object-cover" />
+                        <button
                           type="button"
-                          variant="secondary"
-                          size="sm"
-                          className="absolute top-2 right-2"
-                          onClick={() => setCoverImagePreview("")}
+                          onClick={() => removePhoto(i)}
+                          className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
                         >
-                          Remove
-                        </Button>
+                          <X className="w-4 h-4 text-white" />
+                        </button>
+                        {i === 0 && (
+                          <span className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-[10px] text-center py-0.5">Cover</span>
+                        )}
                       </div>
-                    ) : (
-                      <label className="flex flex-col items-center justify-center w-full h-48 border-2 border-dashed rounded-lg cursor-pointer hover:bg-accent/50 transition-colors">
-                        <div className="flex flex-col items-center justify-center pt-5 pb-6">
-                          <ImageIcon className="w-10 h-10 mb-3 text-muted-foreground" />
-                          <p className="mb-2 text-sm text-muted-foreground">
-                            <span className="font-semibold">Click to upload</span> or drag and drop
-                          </p>
-                          <p className="text-xs text-muted-foreground">PNG, JPG or WEBP (MAX. 5MB)</p>
-                        </div>
+                    ))}
+
+                    {/* Add photo button */}
+                    {photos.length < MAX_PHOTOS && (
+                      <label className="w-full aspect-square rounded-lg border-2 border-dashed flex flex-col items-center justify-center cursor-pointer hover:bg-accent/50 transition-colors">
+                        <Plus className="w-5 h-5 text-muted-foreground mb-1" />
+                        <span className="text-[10px] text-muted-foreground">Add</span>
                         <input
                           type="file"
                           className="hidden"
                           accept="image/*"
-                          onChange={handleImageSelect}
+                          multiple
+                          onChange={handlePhotosSelect}
                         />
                       </label>
                     )}
                   </div>
                 </div>
 
-                {/* Title */}
+                {/* ── Title ── */}
                 <div className="space-y-2">
                   <Label htmlFor="title">Event Title *</Label>
                   <Input
@@ -246,7 +253,7 @@ const CreateCampaign = () => {
                   />
                 </div>
 
-                {/* Slug */}
+                {/* ── Slug ── */}
                 <div className="space-y-2">
                   <Label htmlFor="slug">Event URL</Label>
                   <div className="flex items-center gap-2">
@@ -262,28 +269,52 @@ const CreateCampaign = () => {
                   <p className="text-xs text-muted-foreground">This will be your event's unique URL</p>
                 </div>
 
-                {/* Description */}
+                {/* ── Short Description ── */}
                 <div className="space-y-2">
-                  <Label htmlFor="description">Description</Label>
+                  <Label htmlFor="description">Short Description</Label>
                   <Textarea
                     id="description"
-                    placeholder="Tell people about your event..."
+                    placeholder="One or two sentences summarising your campaign..."
                     value={formData.description}
                     onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                    rows={4}
+                    rows={2}
                   />
                 </div>
 
-                {/* Category */}
+                {/* ── Story ── */}
+                <div className="space-y-2">
+                  <Label htmlFor="story">
+                    Your Story
+                    <span className="ml-2 text-xs font-normal text-muted-foreground">(recommended)</span>
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Tell contributors the full story. Why does this matter? What will the money do? The more you share, the more people will connect with your cause.
+                  </p>
+                  <Textarea
+                    id="story"
+                    placeholder="Share your story here…
+
+Write about what inspired this campaign, how contributions will be used, and why this matters to you. Be as detailed as you'd like — people contribute more when they truly understand the cause."
+                    value={formData.story}
+                    onChange={(e) => {
+                      setFormData({ ...formData, story: e.target.value });
+                      setStoryCharCount(e.target.value.length);
+                    }}
+                    rows={8}
+                    maxLength={10000}
+                    className="resize-y"
+                  />
+                  <p className="text-xs text-right text-muted-foreground">{storyCharCount.toLocaleString()} / 10,000</p>
+                </div>
+
+                {/* ── Category ── */}
                 <div className="space-y-2">
                   <Label htmlFor="category">Event Category *</Label>
                   <Select
                     value={formData.category}
                     onValueChange={(value) => setFormData({ ...formData, category: value })}
                   >
-                    <SelectTrigger id="category">
-                      <SelectValue />
-                    </SelectTrigger>
+                    <SelectTrigger id="category"><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="education">🎓 Education</SelectItem>
                       <SelectItem value="medical">🏥 Medical</SelectItem>
@@ -298,7 +329,7 @@ const CreateCampaign = () => {
                   </Select>
                 </div>
 
-                {/* Goal Amount */}
+                {/* ── Goal Amount ── */}
                 <div className="space-y-2">
                   <Label htmlFor="goal_amount">Goal Amount (KES)</Label>
                   <Input
@@ -313,7 +344,7 @@ const CreateCampaign = () => {
                   <p className="text-xs text-muted-foreground">Leave empty for no goal</p>
                 </div>
 
-                {/* End Date */}
+                {/* ── End Date ── */}
                 <div className="space-y-2">
                   <Label htmlFor="end_date">End Date (Optional)</Label>
                   <Input
@@ -324,7 +355,7 @@ const CreateCampaign = () => {
                   />
                 </div>
 
-                {/* Event Location - Only show for event mode */}
+                {/* ── Event Location ── */}
                 {formData.mode === "event" && (
                   <div className="space-y-2">
                     <Label htmlFor="event_location">Event Location</Label>
@@ -337,7 +368,7 @@ const CreateCampaign = () => {
                   </div>
                 )}
 
-                {/* Theme Color */}
+                {/* ── Theme Color ── */}
                 <div className="space-y-2">
                   <Label htmlFor="theme_color">Theme Color</Label>
                   <div className="flex items-center gap-3">
@@ -357,7 +388,7 @@ const CreateCampaign = () => {
                   </div>
                 </div>
 
-                {/* Mode Selection */}
+                {/* ── Mode Selection ── */}
                 <div className="space-y-3">
                   <Label>Event Type *</Label>
                   <RadioGroup
@@ -374,12 +405,9 @@ const CreateCampaign = () => {
                           <Store className="w-4 h-4" />
                           Merchant / POS
                         </div>
-                        <p className="text-sm text-muted-foreground font-normal">
-                          Perfect for shared bills and offline payments
-                        </p>
+                        <p className="text-sm text-muted-foreground font-normal">Perfect for shared bills and offline payments</p>
                       </Label>
                     </div>
-
                     <div className="flex items-start space-x-3 p-4 border rounded-lg hover:border-primary transition-colors">
                       <RadioGroupItem value="event" id="event" className="mt-1" />
                       <Label htmlFor="event" className="flex-1 cursor-pointer space-y-1">
@@ -387,12 +415,9 @@ const CreateCampaign = () => {
                           <Calendar className="w-4 h-4" />
                           Event / Social
                         </div>
-                        <p className="text-sm text-muted-foreground font-normal">
-                          Great for picnics, parties, and social gatherings
-                        </p>
+                        <p className="text-sm text-muted-foreground font-normal">Great for picnics, parties, and social gatherings</p>
                       </Label>
                     </div>
-
                     <div className="flex items-start space-x-3 p-4 border rounded-lg hover:border-primary transition-colors">
                       <RadioGroupItem value="activism" id="activism" className="mt-1" />
                       <Label htmlFor="activism" className="flex-1 cursor-pointer space-y-1">
@@ -400,21 +425,17 @@ const CreateCampaign = () => {
                           <Shield className="w-4 h-4" />
                           Activism / Cause
                         </div>
-                        <p className="text-sm text-muted-foreground font-normal">
-                          Ideal for protests, causes, and anonymous donations
-                        </p>
+                        <p className="text-sm text-muted-foreground font-normal">Ideal for protests, causes, and anonymous donations</p>
                       </Label>
                     </div>
                   </RadioGroup>
                 </div>
 
-                {/* Visibility */}
+                {/* ── Visibility ── */}
                 <div className="flex items-center justify-between p-4 border rounded-lg">
                   <div className="space-y-0.5">
                     <Label htmlFor="is_public">Public Event</Label>
-                    <p className="text-sm text-muted-foreground">
-                      Make this event visible in the public gallery
-                    </p>
+                    <p className="text-sm text-muted-foreground">Make this event visible in the public gallery</p>
                   </div>
                   <Switch
                     id="is_public"
@@ -423,15 +444,9 @@ const CreateCampaign = () => {
                   />
                 </div>
 
-                {/* Submit Button */}
+                {/* ── Submit ── */}
                 <div className="flex gap-4 pt-4">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => navigate("/app")}
-                    disabled={loading}
-                    className="flex-1"
-                  >
+                  <Button type="button" variant="outline" onClick={() => navigate("/app")} disabled={loading} className="flex-1">
                     Cancel
                   </Button>
                   <Button type="submit" disabled={loading} className="flex-1">
@@ -443,27 +458,24 @@ const CreateCampaign = () => {
             </CardContent>
           </Card>
 
-          {/* Live Preview Section */}
+          {/* ── Live Preview Section ── */}
           <div className="space-y-6">
             <div className="sticky top-4">
               <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
                 <QrCode className="w-5 h-5" />
-                Live Preview - How contributors will see it
+                Live Preview – How contributors will see it
               </h3>
 
-              {/* Campaign Card Preview */}
               <Card className="overflow-hidden">
-                {coverImagePreview ? (
-                  <div className="w-full h-40 overflow-hidden">
-                    <img
-                      src={coverImagePreview}
-                      alt="Cover preview"
-                      className="w-full h-full object-cover"
-                    />
+                {/* Photo strip preview */}
+                {photos.length > 0 ? (
+                  <div className="w-full h-48 overflow-hidden">
+                    <img src={photos[0]} alt="Cover" className="w-full h-full object-cover" />
                   </div>
                 ) : (
-                  <div className="w-full h-40 bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
+                  <div className="w-full h-48 bg-gradient-to-br from-primary/20 to-primary/5 flex flex-col items-center justify-center gap-2">
                     <ImageIcon className="w-12 h-12 text-muted-foreground/50" />
+                    <p className="text-xs text-muted-foreground">Add photos above to see the cover here</p>
                   </div>
                 )}
 
@@ -480,30 +492,26 @@ const CreateCampaign = () => {
 
                   {/* Description */}
                   {formData.description && (
-                    <p className="text-sm text-muted-foreground line-clamp-3">
-                      {formData.description}
-                    </p>
+                    <p className="text-sm text-muted-foreground">{formData.description}</p>
+                  )}
+
+                  {/* Story preview */}
+                  {formData.story && (
+                    <div className="border-l-2 pl-3" style={{ borderColor: formData.theme_color }}>
+                      <p className="text-sm text-muted-foreground line-clamp-4 whitespace-pre-wrap">{formData.story}</p>
+                    </div>
                   )}
 
                   {/* Event Details */}
                   {formData.mode === "event" && (
                     <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
                       {formData.end_date && (
-                        <div className="flex items-center gap-1.5">
-                          <Clock className="w-4 h-4" />
-                          <span>{formatEndDate(formData.end_date)}</span>
-                        </div>
+                        <div className="flex items-center gap-1.5"><Clock className="w-4 h-4" /><span>{formatEndDate(formData.end_date)}</span></div>
                       )}
                       {formData.event_location && (
-                        <div className="flex items-center gap-1.5">
-                          <MapPin className="w-4 h-4" />
-                          <span>{formData.event_location}</span>
-                        </div>
+                        <div className="flex items-center gap-1.5"><MapPin className="w-4 h-4" /><span>{formData.event_location}</span></div>
                       )}
-                      <div className="flex items-center gap-1.5">
-                        <Users className="w-4 h-4" />
-                        <span>0 attending</span>
-                      </div>
+                      <div className="flex items-center gap-1.5"><Users className="w-4 h-4" /><span>0 attending</span></div>
                     </div>
                   )}
 
@@ -511,12 +519,8 @@ const CreateCampaign = () => {
                   {formData.goal_amount && (
                     <div className="space-y-2">
                       <div className="flex justify-between text-sm">
-                        <span className="font-semibold" style={{ color: formData.theme_color }}>
-                          KES 0
-                        </span>
-                        <span className="text-muted-foreground">
-                          of KES {Number(formData.goal_amount).toLocaleString()}
-                        </span>
+                        <span className="font-semibold" style={{ color: formData.theme_color }}>KES 0</span>
+                        <span className="text-muted-foreground">of KES {Number(formData.goal_amount).toLocaleString()}</span>
                       </div>
                       <Progress value={0} className="h-2" />
                     </div>
@@ -526,17 +530,10 @@ const CreateCampaign = () => {
                   <div className="pt-4 border-t space-y-4">
                     <div className="flex justify-center">
                       <div className="bg-white p-3 rounded-lg shadow-sm">
-                        <QRCodeSVG
-                          value={campaignUrl}
-                          size={140}
-                          level="M"
-                          fgColor={formData.theme_color}
-                        />
+                        <QRCodeSVG value={campaignUrl} size={140} level="M" fgColor={formData.theme_color} />
                       </div>
                     </div>
-                    <p className="text-xs text-center text-muted-foreground">
-                      Scan to contribute
-                    </p>
+                    <p className="text-xs text-center text-muted-foreground">Scan to contribute</p>
                   </div>
 
                   {/* Campaign Link */}
@@ -558,23 +555,15 @@ const CreateCampaign = () => {
 
                   {/* Payment Buttons Preview */}
                   <div className="grid grid-cols-2 gap-3 pt-2">
-                    <Button
-                      size="sm"
-                      style={{ backgroundColor: formData.theme_color }}
-                      className="text-white"
-                    >
-                      <Bitcoin className="w-4 h-4 mr-1.5" />
-                      Bitcoin
+                    <Button size="sm" style={{ backgroundColor: formData.theme_color }} className="text-white">
+                      <Bitcoin className="w-4 h-4 mr-1.5" />Bitcoin
                     </Button>
                     <Button size="sm" variant="secondary">
-                      <Smartphone className="w-4 h-4 mr-1.5" />
-                      M-Pesa
+                      <Smartphone className="w-4 h-4 mr-1.5" />M-Pesa
                     </Button>
                   </div>
 
-                  <p className="text-xs text-center text-muted-foreground">
-                    Powered by CrowdPay
-                  </p>
+                  <p className="text-xs text-center text-muted-foreground">Powered by CrowdPay</p>
                 </div>
               </Card>
 
@@ -586,12 +575,10 @@ const CreateCampaign = () => {
                 </p>
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" className="flex-1" onClick={copyLink}>
-                    <Copy className="w-4 h-4 mr-2" />
-                    Copy Link
+                    <Copy className="w-4 h-4 mr-2" />Copy Link
                   </Button>
                   <Button variant="outline" size="sm" className="flex-1">
-                    <QrCode className="w-4 h-4 mr-2" />
-                    Download QR
+                    <QrCode className="w-4 h-4 mr-2" />Download QR
                   </Button>
                 </div>
               </Card>
@@ -610,6 +597,8 @@ const CreateCampaign = () => {
               <ul className="list-disc list-inside text-sm space-y-1 mt-2">
                 <li><strong>Title:</strong> {formData.title || "Not set"}</li>
                 <li><strong>Category:</strong> {formData.category}</li>
+                <li><strong>Photos:</strong> {photos.length > 0 ? `${photos.length} photo(s)` : "No photos"}</li>
+                <li><strong>Story:</strong> {formData.story ? `${storyCharCount} characters` : "No story"}</li>
                 <li><strong>Goal:</strong> {formData.goal_amount ? `KES ${formData.goal_amount}` : "No goal set"}</li>
                 <li><strong>Type:</strong> {formData.mode}</li>
                 <li><strong>Visibility:</strong> {formData.is_public ? "Public" : "Private"}</li>

--- a/frontend/src/pages/EditCampaign.tsx
+++ b/frontend/src/pages/EditCampaign.tsx
@@ -1,0 +1,332 @@
+/**
+ * EditCampaign – lets a campaign creator fix typos and update details.
+ * Pre-fills the form with existing campaign data fetched by ID.
+ * Route: /edit/:id  (auth + owner only)
+ */
+
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
+import { useAuth } from "@/contexts/MockAuthContext";
+import { campaignApi } from "@/services/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { Loader2, X, Plus, AlertCircle, Pencil } from "lucide-react";
+
+const MAX_PHOTOS = 5;
+
+const EditCampaign = () => {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const { toast } = useToast();
+    const { user, session } = useAuth();
+
+    const [loadingData, setLoadingData] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [notFound, setNotFound] = useState(false);
+    const [unauthorized, setUnauthorized] = useState(false);
+
+    const [photos, setPhotos] = useState<string[]>([]);
+    const [storyCharCount, setStoryCharCount] = useState(0);
+
+    const [formData, setFormData] = useState({
+        title: "",
+        description: "",
+        story: "",
+        end_date: "",
+        is_public: true,
+        status: "active" as "active" | "completed" | "cancelled" | "expired",
+    });
+
+    // ── Load existing campaign data ──
+    useEffect(() => {
+        if (!id) return;
+        setLoadingData(true);
+        campaignApi.get(id)
+            .then(({ campaign }) => {
+                // Only the creator can edit
+                if (user && campaign.creator_id !== user.id) {
+                    setUnauthorized(true);
+                    return;
+                }
+
+                setFormData({
+                    title: campaign.title || "",
+                    description: campaign.description || "",
+                    story: campaign.story || "",
+                    end_date: campaign.end_date
+                        ? new Date(campaign.end_date).toISOString().slice(0, 16)
+                        : "",
+                    is_public: campaign.is_public ?? true,
+                    status: (campaign.status as typeof formData.status) || "active",
+                });
+                setStoryCharCount((campaign.story || "").length);
+                setPhotos(Array.isArray(campaign.photos) ? campaign.photos : []);
+            })
+            .catch(() => setNotFound(true))
+            .finally(() => setLoadingData(false));
+    }, [id, user]);
+
+    // ── Photo handling ──
+    const handlePhotosSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = Array.from(e.target.files || []);
+        if (!files.length) return;
+
+        const remaining = MAX_PHOTOS - photos.length;
+        if (remaining <= 0) {
+            toast({ title: "Max photos reached", description: `You can upload up to ${MAX_PHOTOS} photos`, variant: "destructive" });
+            return;
+        }
+
+        const oversized = files.filter(f => f.size > 5 * 1024 * 1024);
+        if (oversized.length) {
+            toast({ title: "File too large", description: "Each photo must be under 5MB", variant: "destructive" });
+            return;
+        }
+
+        files.slice(0, remaining).forEach(file => {
+            const reader = new FileReader();
+            reader.onloadend = () => setPhotos(prev => [...prev, reader.result as string]);
+            reader.readAsDataURL(file);
+        });
+        e.target.value = "";
+    };
+
+    const removePhoto = (index: number) => setPhotos(prev => prev.filter((_, i) => i !== index));
+
+    // ── Save ──
+    const handleSave = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!id || !session?.access_token) return;
+
+        setSaving(true);
+        try {
+            await campaignApi.update(
+                id,
+                {
+                    title: formData.title,
+                    description: formData.description,
+                    story: formData.story || undefined,
+                    photos,
+                    is_public: formData.is_public,
+                    end_date: formData.end_date || undefined,
+                },
+                session.access_token
+            );
+
+            toast({ title: "Campaign updated!", description: "Your changes have been saved." });
+            navigate(`/c/${id}`);
+        } catch (err) {
+            toast({
+                title: "Failed to save",
+                description: err instanceof Error ? err.message : "Please try again",
+                variant: "destructive",
+            });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    // ── States ──
+    if (loadingData) {
+        return (
+            <div className="flex min-h-[60vh] items-center justify-center">
+                <Loader2 className="w-8 h-8 animate-spin text-primary" />
+            </div>
+        );
+    }
+
+    if (notFound) {
+        return (
+            <div className="flex min-h-[60vh] items-center justify-center">
+                <div className="text-center space-y-3">
+                    <AlertCircle className="w-10 h-10 mx-auto text-destructive" />
+                    <p className="font-medium">Campaign not found</p>
+                    <Button onClick={() => navigate("/app")}>Back to dashboard</Button>
+                </div>
+            </div>
+        );
+    }
+
+    if (unauthorized) {
+        return (
+            <div className="flex min-h-[60vh] items-center justify-center">
+                <div className="text-center space-y-3">
+                    <AlertCircle className="w-10 h-10 mx-auto text-destructive" />
+                    <p className="font-medium">You don't have permission to edit this campaign</p>
+                    <Button onClick={() => navigate(`/c/${id}`)}>View campaign</Button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <>
+            <Helmet>
+                <title>Edit Campaign – CrowdPay</title>
+            </Helmet>
+
+            <div className="container mx-auto px-4 py-8 max-w-2xl">
+                {/* Header */}
+                <div className="flex items-center gap-3 mb-8">
+                    <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+                        <Pencil className="w-5 h-5 text-primary" />
+                    </div>
+                    <div>
+                        <h1 className="text-2xl font-bold">Edit Campaign</h1>
+                        <p className="text-muted-foreground text-sm">Fix typos or update your campaign details</p>
+                    </div>
+                </div>
+
+                <Card>
+                    <CardContent>
+                        <form onSubmit={handleSave} className="space-y-6">
+
+                            {/* ── Photos ── */}
+                            <div className="space-y-2">
+                                <Label>
+                                    Photos
+                                    <span className="text-muted-foreground text-xs ml-2">({photos.length}/{MAX_PHOTOS})</span>
+                                </Label>
+                                <p className="text-xs text-muted-foreground">First photo is the cover. Add or remove photos.</p>
+                                <div className="grid grid-cols-5 gap-2">
+                                    {photos.map((src, i) => (
+                                        <div key={i} className="relative group w-full aspect-square rounded-lg overflow-hidden border bg-muted">
+                                            <img src={src} alt={`Photo ${i + 1}`} className="w-full h-full object-cover" />
+                                            <button
+                                                type="button"
+                                                onClick={() => removePhoto(i)}
+                                                className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
+                                            >
+                                                <X className="w-4 h-4 text-white" />
+                                            </button>
+                                            {i === 0 && (
+                                                <span className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-[10px] text-center py-0.5">
+                                                    Cover
+                                                </span>
+                                            )}
+                                        </div>
+                                    ))}
+                                    {photos.length < MAX_PHOTOS && (
+                                        <label className="w-full aspect-square rounded-lg border-2 border-dashed flex flex-col items-center justify-center cursor-pointer hover:bg-accent/50 transition-colors">
+                                            <Plus className="w-5 h-5 text-muted-foreground mb-1" />
+                                            <span className="text-[10px] text-muted-foreground">Add</span>
+                                            <input type="file" className="hidden" accept="image/*" multiple onChange={handlePhotosSelect} />
+                                        </label>
+                                    )}
+                                </div>
+                            </div>
+
+                            {/* ── Title ── */}
+                            <div className="space-y-2">
+                                <Label htmlFor="title">Title *</Label>
+                                <Input
+                                    id="title"
+                                    value={formData.title}
+                                    onChange={e => setFormData({ ...formData, title: e.target.value })}
+                                    required
+                                />
+                            </div>
+
+                            {/* ── Short description ── */}
+                            <div className="space-y-2">
+                                <Label htmlFor="description">Short Description</Label>
+                                <Textarea
+                                    id="description"
+                                    value={formData.description}
+                                    onChange={e => setFormData({ ...formData, description: e.target.value })}
+                                    rows={2}
+                                />
+                            </div>
+
+                            {/* ── Story ── */}
+                            <div className="space-y-2">
+                                <Label htmlFor="story">Story</Label>
+                                <Textarea
+                                    id="story"
+                                    value={formData.story}
+                                    onChange={e => {
+                                        setFormData({ ...formData, story: e.target.value });
+                                        setStoryCharCount(e.target.value.length);
+                                    }}
+                                    rows={8}
+                                    maxLength={10000}
+                                    className="resize-y"
+                                    placeholder="Tell contributors the full story…"
+                                />
+                                <p className="text-xs text-right text-muted-foreground">
+                                    {storyCharCount.toLocaleString()} / 10,000
+                                </p>
+                            </div>
+
+                            {/* ── Status ── */}
+                            <div className="space-y-2">
+                                <Label htmlFor="status">Campaign Status</Label>
+                                <Select
+                                    value={formData.status}
+                                    onValueChange={v => setFormData({ ...formData, status: v as typeof formData.status })}
+                                >
+                                    <SelectTrigger id="status"><SelectValue /></SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="active">✅ Active</SelectItem>
+                                        <SelectItem value="completed">🏁 Completed</SelectItem>
+                                        <SelectItem value="cancelled">❌ Cancelled</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+
+                            {/* ── End date ── */}
+                            <div className="space-y-2">
+                                <Label htmlFor="end_date">End Date (optional)</Label>
+                                <Input
+                                    id="end_date"
+                                    type="datetime-local"
+                                    value={formData.end_date}
+                                    onChange={e => setFormData({ ...formData, end_date: e.target.value })}
+                                />
+                            </div>
+
+                            {/* ── Visibility ── */}
+                            <div className="flex items-center justify-between p-4 border rounded-lg">
+                                <div className="space-y-0.5">
+                                    <Label htmlFor="is_public">Public Campaign</Label>
+                                    <p className="text-sm text-muted-foreground">Show in the public Explore page</p>
+                                </div>
+                                <Switch
+                                    id="is_public"
+                                    checked={formData.is_public}
+                                    onCheckedChange={checked => setFormData({ ...formData, is_public: checked })}
+                                />
+                            </div>
+
+                            {/* ── Actions ── */}
+                            <div className="flex gap-3 pt-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    className="flex-1"
+                                    onClick={() => navigate(`/c/${id}`)}
+                                    disabled={saving}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button type="submit" className="flex-1" disabled={saving}>
+                                    {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                    {saving ? "Saving..." : "Save Changes"}
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+            </div>
+        </>
+    );
+};
+
+export default EditCampaign;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -14,10 +14,13 @@ export interface Campaign {
   creator_email?: string;
   title: string;
   description: string;
+  story?: string;
+  photos?: string[];
   target_amount: number;
   current_amount: number;
   currency: string;
   status: "active" | "completed" | "cancelled" | "expired";
+  is_public: boolean;
   end_date?: string;
   created_at: string;
   updated_at?: string;
@@ -34,9 +37,25 @@ export interface CampaignStatistics {
 export interface CreateCampaignRequest {
   title: string;
   description: string;
+  story?: string;
+  photos?: string[];
+  is_public?: boolean;
   target_amount: number;
   currency?: string;
   end_date?: string;
+}
+
+export interface ContributionItem {
+  id: string;
+  campaign_id: string;
+  contributor_name: string | null;
+  amount: number;
+  currency: string;
+  message?: string | null;
+  is_anonymous: boolean;
+  payment_status: string;
+  created_at: string;
+  paid_at?: string | null;
 }
 
 export interface CampaignResponse {
@@ -220,8 +239,8 @@ export const campaignApi = {
    */
   getContributions: async (
     campaignId: string
-  ): Promise<{ contributions: unknown[]; count: number }> => {
-    return apiCall<{ contributions: unknown[]; count: number }>(
+  ): Promise<{ contributions: ContributionItem[]; count: number }> => {
+    return apiCall<{ contributions: ContributionItem[]; count: number }>(
       `/api/campaigns/${campaignId}/contributions`
     );
   },


### PR DESCRIPTION
- Add story (10k char) and photos (up to 5) to campaign model & DB
- Rewrite Campaign page with Geyser Fund-style layout:
  - Contained photo carousel with blurred backdrop for portrait images
  - Static contribute widget (always visible, appears first on mobile)
  - Live contributions feed with transparency badge
  - Bitcoin Lightning · M-Pesa (soon) · USDT (soon) payment labels
- Rewrite CreateCampaign page with multi-photo upload grid and story textarea with live character count
- Add EditCampaign page (/edit/:id) — pre-filled form for owners to fix typos, update story/photos, status, and visibility
- Show Edit button in campaign nav only to the campaign creator
- Fix is_public bug: private campaigns no longer appear in Explore
- Update PaymentModal header with CrowdPay logo + campaign name
- Add is_public, story, photos columns to supabase_setup.sql DB migration required:
  ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS story TEXT; ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS photos JSONB DEFAULT '[]'::jsonb; ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT TRUE; I have done the migrations in Supabase.